### PR TITLE
[FEATURE] Add getter for viewHelperResolver

### DIFF
--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -131,6 +131,13 @@ abstract class AbstractTemplateView extends AbstractView {
 	}
 
 	/**
+	 * @return ViewHelperResolver
+	 */
+	public function getViewHelperResolver() {
+		return $this->viewHelperResolver;
+	}
+
+	/**
 	 * Inject the Template Parser
 	 *
 	 * @param TemplateParser $templateParser The template parser

--- a/tests/Unit/View/AbstractTemplateViewTest.php
+++ b/tests/Unit/View/AbstractTemplateViewTest.php
@@ -65,6 +65,16 @@ class AbstractTemplateViewTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
+	public function testGetViewHelperResolverReturnsExpectedViewHelperResolver() {
+		$viewHelperResolver = $this->getMock('NamelessCoder\Fluid\Core\ViewHelper\ViewHelperResolver');
+		$this->view->setViewHelperResolver($viewHelperResolver);
+		$result = $this->view->getViewHelperResolver();
+		$this->assertSame($viewHelperResolver, $result);
+	}
+
+	/**
+	 * @test
+	 */
 	public function viewIsPlacedInViewHelperVariableContainer() {
 		$this->viewHelperVariableContainer->expects($this->once())->method('setView')->with($this->view);
 		$this->view->setRenderingContext($this->renderingContext);


### PR DESCRIPTION
This commit adds a getter for the viewHelperResolver to the
TemplateView in order to register namespaces, etc without
creating a new viewHelperResolver