### PR TITLE
[BUGFIX] Don't implement ``render()`` method in abstract classes

### DIFF
--- a/src/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/src/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -50,21 +50,6 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper {
 	}
 
 	/**
-	 * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
-	 *
-	 * @param boolean $condition View helper condition
-	 * @return string the rendered string
-	 * @api
-	 */
-	public function render() {
-		if ($this->arguments['condition']) {
-			return $this->renderThenChild();
-		} else {
-			return $this->renderElseChild();
-		}
-	}
-
-	/**
 	 * @param array $arguments
 	 * @param \Closure $renderChildrenClosure
 	 * @param RenderingContextInterface $renderingContext

--- a/src/Core/ViewHelper/AbstractViewHelper.php
+++ b/src/Core/ViewHelper/AbstractViewHelper.php
@@ -9,6 +9,7 @@ namespace NamelessCoder\Fluid\Core\ViewHelper;
 use NamelessCoder\Fluid\Core\Compiler\TemplateCompiler;
 use NamelessCoder\Fluid\Core\Parser;
 use NamelessCoder\Fluid\Core\Parser\SyntaxTree\NodeInterface;
+use NamelessCoder\Fluid\Core\Parser\SyntaxTree\TextNode;
 use NamelessCoder\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use NamelessCoder\Fluid\Core\Rendering\RenderingContextInterface;
 use NamelessCoder\Fluid\Core\Variables\VariableProviderInterface;
@@ -236,7 +237,7 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 * @throws Exception
 	 */
 	protected function callRenderMethod() {
-		return $this->render();
+		return call_user_func(array($this, 'render'));
 	}
 
 	/**
@@ -347,16 +348,6 @@ abstract class AbstractViewHelper implements ViewHelperInterface {
 	 * @api
 	 */
 	public function initializeArguments() {
-	}
-
-	/**
-	 * Render method you need to implement for your custom view helper.
-	 *
-	 * @return string rendered string, view helper specific
-	 * @api
-	 */
-	public function render() {
-		return $this->renderChildren();
 	}
 
 	/**

--- a/src/Core/ViewHelper/ViewHelperInterface.php
+++ b/src/Core/ViewHelper/ViewHelperInterface.php
@@ -81,6 +81,15 @@ interface ViewHelperInterface {
 	 */
 	public function initializeArguments();
 
+//	/**
+//	 * Render method you need to implement for your custom view helper.
+//	 * Note: This method is commented out in order to avoid conflicts with different method signatures in the implementation
+//	 *
+//	 * @return mixed usually the rendered string, depending on the view helper
+//	 * @api
+//	 */
+//	public function render();
+
 	/**
 	 * Here follows a more detailed description of the arguments of this function:
 	 *

--- a/src/ViewHelpers/IfViewHelper.php
+++ b/src/ViewHelpers/IfViewHelper.php
@@ -83,4 +83,19 @@ use NamelessCoder\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IfViewHelper extends AbstractConditionViewHelper {
 
+	/**
+	 * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+	 *
+	 * @param boolean $condition View helper condition
+	 * @return string the rendered string
+	 * @api
+	 */
+	public function render() {
+		if ($this->arguments['condition']) {
+			return $this->renderThenChild();
+		} else {
+			return $this->renderElseChild();
+		}
+	}
+
 }

--- a/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -66,7 +66,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function argumentsCanBeRegistered() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'This is a name';
 		$description = 'Example desc';
@@ -83,7 +83,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \NamelessCoder\Fluid\Core\ViewHelper\Exception
 	 */
 	public function registeringTheSameArgumentNameAgainThrowsException() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'shortName';
 		$description = 'Example desc';
@@ -98,7 +98,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function overrideArgumentOverwritesExistingArgumentDefinition() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$name = 'argumentName';
 		$description = 'argument description';
@@ -118,7 +118,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \NamelessCoder\Fluid\Core\ViewHelper\Exception
 	 */
 	public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', NULL, array(), '', FALSE);
 
 		$viewHelper->_call('overrideArgument', 'argumentName', 'string', 'description', TRUE);
 	}
@@ -127,7 +127,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function prepareArgumentsCallsInitializeArguments() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'initializeArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('initializeArguments'), array(), '', FALSE);
 
 		$viewHelper->expects($this->once())->method('initializeArguments');
 
@@ -138,7 +138,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsCallsPrepareArguments() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array()));
 
@@ -149,7 +149,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsAcceptsAllObjectsImplemtingArrayAccessAsAnArray() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => new \ArrayObject));
 		$viewHelper->expects($this->once())->method('prepareArguments')->will($this->returnValue(array('test' => new ArgumentDefinition('test', 'array', FALSE, 'documentation'))));
@@ -160,7 +160,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @test
 	 */
 	public function validateArgumentsCallsTheRightValidators() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => 'Value of argument'));
 
@@ -176,7 +176,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setArguments(array('test' => 'test'));
 
@@ -212,7 +212,7 @@ class AbstractViewHelperTest extends UnitTestCase {
 		$renderingContext->setVariableProvider($templateVariableContainer);
 		$renderingContext->injectViewHelperVariableContainer($viewHelperVariableContainer);
 
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('render', 'prepareArguments'), array(), '', FALSE);
+		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('prepareArguments'), array(), '', FALSE);
 
 		$viewHelper->setRenderingContext($renderingContext);
 
@@ -296,16 +296,6 @@ class AbstractViewHelperTest extends UnitTestCase {
 			array(new ArgumentDefinition('test', 'integer', '', TRUE), new \ArrayIterator(array('bar'))),
 			array(new ArgumentDefinition('test', 'object', '', TRUE), 'test'),
 		);
-	}
-
-	/**
-	 * @test
-	 */
-	public function testRenderCallsAndReturnsRenderChildren() {
-		$viewHelper = $this->getAccessibleMock('NamelessCoder\Fluid\Core\ViewHelper\AbstractViewHelper', array('renderChildren'), array(), '', FALSE);
-		$viewHelper->expects($this->once())->method('renderChildren')->willReturn('foobar');
-		$result = $viewHelper->render();
-		$this->assertEquals('foobar', $result);
 	}
 
 	/**


### PR DESCRIPTION
This removes the ``render()`` method from the ``AbstractViewHelper``
class in order to prevent PHP errors when a subclass overrides the
method with a different signature (i.e. including parameters).

This also moves ``AbstractConditionViewHelper::render()`` to the
``IfViewHelper`` implementation for the same reason.