### PR TITLE
[FEATURE] Add getScopeCopy() to VariableProvider

### DIFF
--- a/src/Core/Variables/StandardVariableProvider.php
+++ b/src/Core/Variables/StandardVariableProvider.php
@@ -29,6 +29,18 @@ class StandardVariableProvider implements VariableProviderInterface {
 	}
 
 	/**
+	 * @param array $variables
+	 * @return VariableProviderInterface
+	 */
+	public function getScopeCopy(array $variables) {
+		if (!array_key_exists('settings', $variables) && array_key_exists('settings', $this->variables)) {
+			$variables['settings'] = $this->variables['settings'];
+		}
+		$className = get_class($this);
+		return new $className($variables);
+	}
+
+	/**
 	 * Set the source data used by this VariableProvider. The
 	 * source can be any type, but the type must of course be
 	 * supported by the VariableProvider itself.

--- a/src/Core/Variables/VariableProviderInterface.php
+++ b/src/Core/Variables/VariableProviderInterface.php
@@ -28,6 +28,20 @@ interface VariableProviderInterface extends \ArrayAccess {
 	public function __construct(array $variables = array());
 
 	/**
+	 * Gets a fresh instance of this type of VariableProvider
+	 * and fills it with the variables passed in $variables.
+	 *
+	 * Can be overridden to enable special instance creation
+	 * of the new VariableProvider as well as take care of any
+	 * automatically transferred variables (in the default
+	 * implementation the $settings variable is transferred).
+	 *
+	 * @param array $variables
+	 * @return VariableProviderInterface
+	 */
+	public function getScopeCopy(array $variables);
+
+	/**
 	 * Set the source data used by this VariableProvider. The
 	 * source can be any type, but the type must of course be
 	 * supported by the VariableProvider itself.

--- a/src/View/AbstractTemplateView.php
+++ b/src/View/AbstractTemplateView.php
@@ -307,8 +307,7 @@ abstract class AbstractTemplateView extends AbstractView {
 			$renderingTypeOnNextLevel = self::RENDERING_TEMPLATE;
 		} else {
 			$renderingContext = clone $renderingContext;
-			$inherited = $renderingContext->getVariableProvider();
-			$renderingContext->setVariableProvider($variables ? new StandardVariableProvider($variables) : $inherited);
+			$renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
 			$renderingTypeOnNextLevel = $this->getCurrentRenderingType();
 		}
 
@@ -371,9 +370,8 @@ abstract class AbstractTemplateView extends AbstractView {
 				return $paths->getPartialSource($partialName);
 			}
 		);
-		$variableContainer = new StandardVariableProvider($variables);
 		$renderingContext = clone $this->getCurrentRenderingContext();
-		$renderingContext->setVariableProvider($variableContainer);
+		$renderingContext->setVariableProvider($renderingContext->getVariableProvider()->getScopeCopy($variables));
 		$this->startRendering(self::RENDERING_PARTIAL, $parsedPartial, $renderingContext);
 		if ($sectionName !== NULL) {
 			$output = $this->renderSection($sectionName, $variables, $ignoreUnknown);


### PR DESCRIPTION
Implementations will use this method to create a clean-scoped copy of the VariableProvider with specified variables. This means that each VariableProvider can control how new instances are created - and, for example, can transfer any permanent/global variables to sub-scopes.

By default, the `settings` variable is now transferred as such!