### PR TITLE
[FEATURE] Support for quoted keys in arrays

### DIFF
--- a/src/Core/Parser/Patterns.php
+++ b/src/Core/Parser/Patterns.php
@@ -194,22 +194,26 @@ abstract class Patterns {
 	 *
 	 */
 	static public $SCAN_PATTERN_SHORTHANDSYNTAX_ARRAYS = '/^
-		(?P<Recursion>                                  # Start the recursive part of the regular expression - describing the array syntax
-			{                                           # Each array needs to start with {
-				(?P<Array>                              # Start sub-match
+		(?P<Recursion>                                             # Start the recursive part of the regular expression - describing the array syntax
+			{                                                      # Each array needs to start with {
+				(?P<Array>                                         # Start sub-match
 					(?:
-						\s*[a-zA-Z0-9\-_]+              # The keys of the array
-						\s*:\s*                         # Key|Value delimiter :
-						(?:                             # Possible value options:
-							"(?:\\\"|[^"])*"            # Double quoted string
-							|\'(?:\\\\\'|[^\'])*\'      # Single quoted string
-							|[a-zA-Z0-9\-_.]+           # variable identifiers
-							|(?P>Recursion)             # Another sub-array
-						)                               # END possible value options
-						\s*,?                           # There might be a , to separate different parts of the array
-					)*                                  # The above cycle is repeated for all array elements
-				)                                       # End array sub-match
-			}                                           # Each array ends with }
+						\s*(
+							[a-zA-Z0-9\\-_]+                       # Unquoted key
+							|"(?:\\\"|[^"])+"                      # Double quoted key, supporting more characters like dots and square brackets
+							|\'(?:\\\\\'|[^\'])+\'                 # Single quoted key, supporting more characters like dots and square brackets
+						)
+						\s*:\s*                                    # Key|Value delimiter :
+						(?:                                        # Possible value options:
+							"(?:\\\"|[^"])*"                       # Double quoted string
+							|\'(?:\\\\\'|[^\'])*\'                 # Single quoted string
+							|[a-zA-Z0-9\-_.]+                      # variable identifiers
+							|(?P>Recursion)                        # Another sub-array
+						)                                          # END possible value options
+						\s*,?                                      # There might be a , to separate different parts of the array
+					)*                                             # The above cycle is repeated for all array elements
+				)                                                  # End array sub-match
+			}                                                      # Each array ends with }
 		)$/x';
 
 	/**
@@ -219,7 +223,11 @@ abstract class Patterns {
 	 */
 	static public $SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS = '/
 		(?P<ArrayPart>                                             # Start sub-match
-			(?P<Key>[a-zA-Z0-9\-_]+)                               # The keys of the array
+			(?P<Key>                                               # The keys of the array
+				[a-zA-Z0-9\\-_]+                                   # Unquoted
+				|"(?:\\\"|[^"])+"                                  # Double quoted
+				|\'(?:\\\\\'|[^\'])+\'                             # Single quoted
+			)
 			\s*:\s*                                                # Key|Value delimiter :
 			(?:                                                    # Possible value options:
 				(?P<QuotedString>                                  # Quoted string

--- a/src/Core/Parser/TemplateParser.php
+++ b/src/Core/Parser/TemplateParser.php
@@ -553,7 +553,7 @@ class TemplateParser {
 		preg_match_all(Patterns::$SPLIT_PATTERN_SHORTHANDSYNTAX_ARRAY_PARTS, $arrayText, $matches, PREG_SET_ORDER);
 		$arrayToBuild = array();
 		foreach ($matches as $singleMatch) {
-			$arrayKey = $singleMatch['Key'];
+			$arrayKey = $this->unquoteString($singleMatch['Key']);
 			if (!empty($singleMatch['VariableIdentifier'])) {
 				$arrayToBuild[$arrayKey] = new ObjectAccessorNode($singleMatch['VariableIdentifier']);
 			} elseif (array_key_exists('Number', $singleMatch) && (!empty($singleMatch['Number']) || $singleMatch['Number'] === '0' )) {


### PR DESCRIPTION
The syntax for Fluid arrays is based on the JSON syntax, but up to now
it didn't support quoted arrays, so::

 {x:someViewHelper(arrayArgument: '{"foo": "bar"}')}

wouldn't parse.

With this change the parser is a little less strict for arrays allowing
the keys to be quoted with single or double quotes.
It also allows to use special characters within quoted keys::

 <x:someViewHelper arrayArgument="{'@this[will]': 'work'}" />
 {x:someViewhelper(arrayArgument: '{"and.so": "will.this"}'}

See https://jira.neos.io/browse/FLOW-248 for more information.