### PR TITLE
[BUGFIX] ViewHelper child nodes default to NULL

### DIFF
--- a/src/Core/Parser/SyntaxTree/AbstractNode.php
+++ b/src/Core/Parser/SyntaxTree/AbstractNode.php
@@ -29,7 +29,11 @@ abstract class AbstractNode implements NodeInterface {
 	 * @throws Parser\Exception
 	 */
 	public function evaluateChildNodes(RenderingContextInterface $renderingContext) {
-		if (count($this->childNodes) === 1) {
+		$numberOfChildNodes = count($this->childNodes);
+		if ($numberOfChildNodes === 0) {
+			return NULL;
+		}
+		if ($numberOfChildNodes === 1) {
 			return $this->evaluateChildNode($this->childNodes[0], $renderingContext, FALSE);
 		}
 		$output = '';

--- a/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
+++ b/tests/Unit/Core/Parser/SyntaxTree/AbstractNodeTest.php
@@ -40,6 +40,14 @@ class AbstractNodeTest extends UnitTestCase {
 	/**
 	 * @test
 	 */
+	public function evaluateChildNodesReturnsNullIfNoChildNodesExist() {
+		$abstractNode = $this->getMock('NamelessCoder\Fluid\Core\Parser\SyntaxTree\AbstractNode', array('evaluate'));
+		$this->assertNull($abstractNode->evaluateChildNodes($this->renderingContext));
+	}
+
+	/**
+	 * @test
+	 */
 	public function evaluateChildNodeThrowsExceptionIfChildNodeCannotBeCastToString() {
 		$this->childNode->expects($this->once())->method('evaluate')->with($this->renderingContext)->willReturn(new \DateTime('now'));
 		$method = new \ReflectionMethod($this->abstractNode, 'evaluateChildNode');


### PR DESCRIPTION
This fixes a regression that changed the behavior of
``ViewHelperInterface::renderChildren()`` when using self-closing
ViewHelpers like:

```
<x:someViewHelper />
```

In that case ``renderChildren()`` is supposed to return ``NULL``
but it returned an empty string instead.